### PR TITLE
mount docker-distributed repo to /work/docker-distributed instead of /work

### DIFF
--- a/kubernetes/jupyter-notebook.yaml
+++ b/kubernetes/jupyter-notebook.yaml
@@ -37,7 +37,7 @@ spec:
             - name: http
               containerPort: 8888
           volumeMounts:
-            - mountPath: /work
+            - mountPath: /work/docker-distributed
               name: docker-distributed-repo
       volumes:
         - name: docker-distributed-repo


### PR DESCRIPTION
By mounting the git repo to `/work`, `/work/bin/start-notebook.sh` is no longer accessible and the `jupyter-notebook` container fails to startup. Simply mounting to `/work/docker-distributed` instead fixes this and the cluster will startup. Tested on Google Container Engine.